### PR TITLE
Update to use layout management

### DIFF
--- a/src/BookmarkWindow.cpp
+++ b/src/BookmarkWindow.cpp
@@ -1,6 +1,7 @@
 #include <View.h>
 #include <String.h>
 #include <Alert.h>
+#include <LayoutBuilder.h>
 #include <Messenger.h>
 #include <File.h>
 #include <Path.h>
@@ -23,7 +24,7 @@ static const char* kCancel = B_TRANSLATE("Cancel");
 static const char* kOK = B_TRANSLATE("OK");
 
 TBookmarkWindow::TBookmarkWindow(float x, float y, const char *title, const char *dir)
-	:	BWindow(BRect(x, y, x + 290, y + 250), title, B_FLOATING_WINDOW_LOOK,
+	:	BWindow(BRect(x, y, x + 580, y + 500), title, B_FLOATING_WINDOW_LOOK,
 				B_MODAL_APP_WINDOW_FEEL, B_NOT_RESIZABLE | B_NOT_ZOOMABLE)
 {
 	fBookmarkDir.SetTo(dir);
@@ -53,25 +54,30 @@ TBookmarkWindow::TBookmarkWindow(float x, float y, const char *title, const char
 	fRemotePath->SetDivider(div);
 	fLocalPath->SetDivider(div);
 	
-	bgview->AddChild(fBookmarkName);
-	bgview->AddChild(fHostAddress);
-	bgview->AddChild(fPort);
-	bgview->AddChild(fUsername);
-	bgview->AddChild(fPassword);
-	bgview->AddChild(fEncoder);
-	bgview->AddChild(fRemotePath);
-	bgview->AddChild(fLocalPath);
+	
 	
 	fSaveAndConnectButton = new BButton(BRect(10, 215, 140, 240), "Connect", B_TRANSLATE("Connect"), new BMessage(CONNECT_CLICKED));
-	bgview->AddChild(fSaveAndConnectButton);
 	fSaveAndConnectButton->SetEnabled(false);
 	
 	fSaveButton = new BButton(BRect(150, 215, 210, 240), "Save", B_TRANSLATE("Save"), new BMessage(SAVE_CLICKED));
-	bgview->AddChild(fSaveButton);
 	fSaveButton->SetEnabled(false);
 	
 	BButton *cancelButton = new BButton(BRect(220, 215, 280, 240), "Cancel", kCancel, new BMessage(B_QUIT_REQUESTED));
-	bgview->AddChild(cancelButton);
+	
+	BLayoutBuilder::Group<>(bgview,B_VERTICAL,2)
+		.Add(fBookmarkName)
+		.Add(fHostAddress)
+		.Add(fPort)
+		.Add(fUsername)
+		.Add(fPassword)
+		.Add(fEncoder)
+		.Add(fRemotePath)
+		.Add(fLocalPath)
+		.AddGroup(B_HORIZONTAL,10)
+			.Add(fSaveAndConnectButton,2)
+			.Add(fSaveButton,1)
+			.Add(cancelButton,1)
+		.End();
 	
 	fBookmarkName->SetTarget(this);
 	fHostAddress->SetTarget(this);

--- a/src/ChmodWindow.cpp
+++ b/src/ChmodWindow.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <Catalog.h>
 #include <String.h>
+#include <LayoutBuilder.h>
 #include "ChmodWindow.h"
 
 #undef B_TRANSLATION_CONTEXT
@@ -20,12 +21,6 @@ TChmodWindow::TChmodWindow(float ix, float iy, const char *title)
 	AddChild(bgView);
 	
 	float r = 40, w = 70, x = 100, ow = 80, gr = 140, ot = 200, xd = 15, yd = 15;
-	bgView->AddChild(new BStringView(BRect(10, r, ow - 2, r + yd + 3), "", B_TRANSLATE("Read:")));
-	bgView->AddChild(new BStringView(BRect(10, w, ow - 2, w + yd + 3), "", B_TRANSLATE("Write:")));
-	bgView->AddChild(new BStringView(BRect(10, x, ow - 2, x + yd + 3), "", B_TRANSLATE("Execute:")));
-	bgView->AddChild(new BStringView(BRect(ow - 10, r - 20, ow + 30, r - 3), "", B_TRANSLATE("Owner")));
-	bgView->AddChild(new BStringView(BRect(gr - 10, r - 20, gr + 30, r - 3), "", B_TRANSLATE("Group")));
-	bgView->AddChild(new BStringView(BRect(ot - 10, r - 20, ot + 30, r - 3), "", B_TRANSLATE("Other")));
 	fOwnerRead  = new BCheckBox(BRect(ow, r, ow + xd, r + yd), "OwnerRead", "", NULL);
 	fOwnerWrite = new BCheckBox(BRect(ow, w, ow + xd, w + yd), "OwnerWrite", "", NULL);
 	fOwnerExec  = new BCheckBox(BRect(ow, x, ow + xd, x + yd), "OwnerExec", "", NULL);
@@ -35,20 +30,30 @@ TChmodWindow::TChmodWindow(float ix, float iy, const char *title)
 	fOtherRead  = new BCheckBox(BRect(ot, r, ot + xd, r + yd), "OtherRead", "", NULL);
 	fOtherWrite = new BCheckBox(BRect(ot, w, ot + xd, w + yd), "OtherWrite", "", NULL);
 	fOtherExec  = new BCheckBox(BRect(ot, x, ot + xd, x + yd), "OtherExec", "", NULL);
-	bgView->AddChild(fOwnerRead);
-	bgView->AddChild(fOwnerWrite);
-	bgView->AddChild(fOwnerExec);
-	bgView->AddChild(fGroupRead);
-	bgView->AddChild(fGroupWrite);
-	bgView->AddChild(fGroupExec);
-	bgView->AddChild(fOtherRead);
-	bgView->AddChild(fOtherWrite);
-	bgView->AddChild(fOtherExec);
 	fOKButton = new BButton(BRect(10, 140, 100, 160), "", B_TRANSLATE("Change"), new BMessage(OK_CLICKED));
-	bgView->AddChild(fOKButton);
 	fCancelButton = new BButton(BRect(170, 140, 260, 160), "", B_TRANSLATE("Cancel"), new BMessage(B_QUIT_REQUESTED));
-	bgView->AddChild(fCancelButton);
-	
+	BLayoutBuilder::Group<>(bgView,B_VERTICAL,10)
+		.AddGrid(10,10)
+			.Add(new BStringView(BRect(10, r, ow - 2, r + yd + 3), "", B_TRANSLATE("Read:")),0,1)
+			.Add(new BStringView(BRect(10, w, ow - 2, w + yd + 3), "", B_TRANSLATE("Write:")),0,2)
+			.Add(new BStringView(BRect(10, x, ow - 2, x + yd + 3), "", B_TRANSLATE("Execute:")),0,3)
+			.Add(new BStringView(BRect(ow - 10, r - 20, ow + 30, r - 3), "", B_TRANSLATE("Owner")),1,0)
+			.Add(new BStringView(BRect(gr - 10, r - 20, gr + 30, r - 3), "", B_TRANSLATE("Group")),2,0)
+			.Add(new BStringView(BRect(ot - 10, r - 20, ot + 30, r - 3), "", B_TRANSLATE("Other")),3,0)
+			.Add(fOwnerRead,1,1)
+			.Add(fOwnerWrite,1,2)
+			.Add(fOwnerExec,1,3)
+			.Add(fGroupRead,2,1)
+			.Add(fGroupWrite,2,2)
+			.Add(fGroupExec,2,3)
+			.Add(fOtherRead,3,1)
+			.Add(fOtherWrite,3,2)
+			.Add(fOtherExec,3,3)
+		.End()
+		.AddGrid(10,10)
+			.Add(fOKButton,0,0)
+			.Add(fCancelButton,1,0)
+		.End();
 	AddShortcut('W', 0, new BMessage(B_QUIT_REQUESTED));
 	
 	fStatus = B_BUSY;

--- a/src/FTPLooper.cpp
+++ b/src/FTPLooper.cpp
@@ -530,8 +530,8 @@ void TFtpLooper::Download(BMessage *msg)
 	if (msg->FindRect("rect", &rect) == B_OK) {
 		rect.left += 80;
 		rect.top += 80;
-		rect.right = rect.left + 300;
-		rect.bottom = rect.top + 91;
+		rect.right = rect.left + 600;
+		rect.bottom = rect.top + 182;
 	}
 	
 	progressWindow = new TProgressWindow(rect, "", &fAbort);

--- a/src/ProgressWindow.cpp
+++ b/src/ProgressWindow.cpp
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <LayoutBuilder.h>
+#include <Font.h>
 #include <Catalog.h>
 #include <Entry.h>
 #include <File.h>
@@ -18,32 +20,37 @@ extern const char* kAppName;
 TProgressView::TProgressView(BRect frame, const char *name)
 	:	BView(frame, name, B_FOLLOW_LEFT | B_FOLLOW_TOP, B_PULSE_NEEDED)
 {
+	BFont font;
+
 	SetViewColor(217, 217, 217);
 	
 	float right = Bounds().right - 5;
 	
-	fFileNameView = new BStringView(BRect(3, 2, right, 20),
+	fFileNameView = new BStringView(
 		"FileNameView", "");
 	AddChild(fFileNameView);
 	
-	fStatusBar = new BStatusBar(BRect(3, 22, right, 50),
+	fStatusBar = new BStatusBar(
 		"StatusBar", "FileName", " / 0");
 	fStatusBar->SetTrailingText("0");
-	fStatusBar->SetBarHeight(13);
-	AddChild(fStatusBar);
+	fStatusBar->SetBarHeight(font.Size() + 1);
 	
-	fAvgStringView = new BStringView(BRect(5, 54, right / 2, 68), "AvgStringView", "999999.9KB/s");
-	AddChild(fAvgStringView);
+	fAvgStringView = new BStringView("AvgStringView", "999999.9KB/s");
 	
-	fETAStringView = new BStringView(BRect(10 + right / 2, 54, right, 68), "ETAStringView", "99999:99");
+	fETAStringView = new BStringView("ETAStringView", "99999:99");
 	fETAStringView->SetAlignment(B_ALIGN_RIGHT);
-	AddChild(fETAStringView);
 	
-	fCancelButton = new BButton(BRect(right - 65, 69, right, 87),
+	fCancelButton = new BButton(
 		"CancelButton", B_TRANSLATE("Cancel"), new BMessage(MSG_TRANSFER_CANCEL));
-	fCancelButton->ResizeTo(65, 20);
-	AddChild(fCancelButton);
-	
+	BLayoutBuilder::Group<>(this,B_VERTICAL,2)
+		.SetInsets(10)
+		.Add(fFileNameView)
+		.Add(fStatusBar)
+		.AddGrid(10,10)
+			.Add(fETAStringView,0,0)
+			.Add(fCancelButton,1,0)
+		.End()
+	;
 	fCurrentValue = 0;
 }
 

--- a/src/RenameWindow.cpp
+++ b/src/RenameWindow.cpp
@@ -1,4 +1,5 @@
 #include <Application.h>
+#include <LayoutBuilder.h>
 #include <Catalog.h>
 #include "RenameWindow.h"
 
@@ -19,14 +20,19 @@ TRenameWindow::TRenameWindow(float x, float y,
 	bgView->SetViewColor(217,217,217);
 	AddChild(bgView);
 	
-	fTextControl = new BTextControl(BRect(15, 15, 320, 35), "NewName", caption, oldName, NULL);
-	fTextControl->SetDivider(65);
+	fTextControl = new BTextControl(BRect(0,0,1,1), "NewName", caption, oldName, NULL);
+	fTextControl->SetDivider(fTextControl->StringWidth(caption));
 	fTextControl->SetText(oldName);
-	bgView->AddChild(fTextControl);
-	fOKButton = new BButton(BRect(10, 70, 100, 90), "", B_TRANSLATE("OK"), new BMessage(OK_CLICKED));
-	bgView->AddChild(fOKButton);
-	fCancelButton = new BButton(BRect(230, 70, 320, 90), "", B_TRANSLATE("Cancel"), new BMessage(B_QUIT_REQUESTED));
-	bgView->AddChild(fCancelButton);
+	fOKButton = new BButton(BRect(0,0,1,1), "", B_TRANSLATE("OK"), new BMessage(OK_CLICKED));
+	fCancelButton = new BButton(BRect(0,0,1,1), "", B_TRANSLATE("Cancel"), new BMessage(B_QUIT_REQUESTED));
+
+	BLayoutBuilder::Group<>(bgView,B_VERTICAL,10)
+		.SetInsets(10)
+		.Add(fTextControl)
+		.AddGrid(10,10)
+			.Add(fOKButton,0,0)
+			.Add(fCancelButton,1,0)
+		.End();
 	
 	AddShortcut('W', 0, new BMessage(B_QUIT_REQUESTED));
 	


### PR DESCRIPTION
Fixes https://github.com/HaikuArchives/FtpPositive/issues/5

There are still some problems that I cannot solve, so I will ask about them along with this PR.

- [ ] Some floating windows are too small for bigger fonts. I doubled the sizes as a workaround, but I need a better solution to this. Should I calculate the sizes using some kind of formula, or is there a function in the API?
- [ ] The navigation icons can not be scaled
- [ ] The file list scroll bar is missing (frankly confused at this one)
- [ ] When starting with a large window, resizing it down causes some controls to be clipped out
- [ ] The <n> items status is missing too

